### PR TITLE
test: add additional tests for some previously uncovered files/cases

### DIFF
--- a/src/components/ContrastItem.js
+++ b/src/components/ContrastItem.js
@@ -29,7 +29,7 @@ const ContrastItem = ({ label, subtext, contrast, min }) => (
   <Row css="align-items: center;margin: 8px 0;">
     <LabelContainer>
       <Label>{label}</Label>
-      {subtext && <Subtext>{subtext}</Subtext>}
+      {subtext && <Subtext data-testid="contrast-subtext">{subtext}</Subtext>}
     </LabelContainer>
     <ContrastStatus isPass={contrast >= min} />
   </Row>

--- a/src/components/__tests__/ColorField.test.js
+++ b/src/components/__tests__/ColorField.test.js
@@ -90,13 +90,25 @@ describe('ColorField', () => {
 
   test('should not attempt to increment or decrement if it is a HEX field', () => {
     const { getByTestId } = render(
-      <ColorField {...mockProps} value={50} isHex />
+      <ColorField {...mockProps} value="ABABAB" isHex />
     )
 
     const input = getByTestId('color-field')
 
     fireEvent.keyDown(input, ARROW_UP)
     fireEvent.keyDown(input, ARROW_DOWN)
+
+    expect(mockUpdateColor).not.toHaveBeenCalled()
+  })
+
+  test('should not update the color value if attempting to exceed max HEX character count', () => {
+    const { getByTestId } = render(
+      <ColorField {...mockProps} value="ABABAB" isHex />
+    )
+
+    fireEvent.change(getByTestId('color-field'), {
+      target: { value: 'ABABABA' },
+    })
 
     expect(mockUpdateColor).not.toHaveBeenCalled()
   })

--- a/src/components/__tests__/ContrastItem.test.js
+++ b/src/components/__tests__/ContrastItem.test.js
@@ -1,0 +1,70 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+
+import ContrastItem from '../ContrastItem'
+
+describe('ContrastItem', () => {
+  test('should render ContrastItem with the provided data', () => {
+    const { getByText } = render(
+      <ContrastItem
+        label="mockLabel"
+        subtext="mockSubtext"
+        contrast={7.5}
+        min={4}
+      />
+    )
+
+    expect(getByText(/mocklabel/i)).toBeInTheDocument()
+    expect(getByText(/mocksubtext/i)).toBeInTheDocument()
+  })
+
+  test('should show a PASS status if the contrast exceeds the minimum', () => {
+    const { getByText, queryByText } = render(
+      <ContrastItem
+        label="mockLabel"
+        subtext="mockSubtext"
+        contrast={7.5}
+        min={4}
+      />
+    )
+
+    expect(getByText(/pass/i)).toBeInTheDocument()
+    expect(queryByText(/fail/i)).toBeNull()
+  })
+
+  test('should show a FAIL status if the contrast does not meet the minimum', () => {
+    const { getByText, queryByText } = render(
+      <ContrastItem
+        label="mockLabel"
+        subtext="mockSubtext"
+        contrast={2.75}
+        min={4}
+      />
+    )
+
+    expect(getByText(/fail/i)).toBeInTheDocument()
+    expect(queryByText(/pass/i)).toBeNull()
+  })
+
+  test('should show a PASS status if the contrast is equal to the minimum', () => {
+    const { getByText, queryByText } = render(
+      <ContrastItem
+        label="mockLabel"
+        subtext="mockSubtext"
+        contrast={4}
+        min={4}
+      />
+    )
+
+    expect(getByText(/pass/i)).toBeInTheDocument()
+    expect(queryByText(/fail/i)).toBeNull()
+  })
+
+  test('should not render a subtext element if no subtext is provided', () => {
+    const { queryByTestId } = render(
+      <ContrastItem label="mockLabel" contrast={4} min={4} />
+    )
+
+    expect(queryByTestId('contrast-subtext')).toBeNull()
+  })
+})

--- a/src/components/__tests__/Section.test.js
+++ b/src/components/__tests__/Section.test.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+
+import Section from '../Section'
+
+test('Section should render section header and children', () => {
+  const { getByText } = render(
+    <Section header="Mock header">
+      <div>this is a child component</div>
+    </Section>
+  )
+
+  expect(getByText(/mock header/i)).toBeInTheDocument()
+  expect(getByText(/this is a child component/i)).toBeInTheDocument()
+})


### PR DESCRIPTION
Added tests for `ContrastItem`, `Section`, and a previously untested negative HEX case in `ColorField`