### PR TITLE
refactor: create a shared type for color number input values

### DIFF
--- a/src/components/ColorField.tsx
+++ b/src/components/ColorField.tsx
@@ -52,8 +52,8 @@ type Props = {
   prefix?: string
   size?: number
   suffix?: string
-  updateColor: (val: number | string) => void
-  value: number | string
+  updateColor: (val: ColorNumberInput) => void
+  value: ColorNumberInput
 }
 
 const ColorField = (props: Props) => {

--- a/src/components/ColorSet.tsx
+++ b/src/components/ColorSet.tsx
@@ -158,17 +158,17 @@ const ColorSet = (props: Props) => {
 
 type Props = {
   colors: {
-    b: number | string
-    g: number | string
-    h: number | string
+    b: ColorNumberInput
+    g: ColorNumberInput
+    h: ColorNumberInput
     hex: string
-    l: number | string
-    r: number | string
-    s: number | string
+    l: ColorNumberInput
+    r: ColorNumberInput
+    s: ColorNumberInput
   }
   header: string
   setIdentifier: string
-  updateColor: (key: string, val: number | string) => void
+  updateColor: (key: string, val: ColorNumberInput) => void
 }
 
 export default ColorSet

--- a/src/ts/index.d.ts
+++ b/src/ts/index.d.ts
@@ -9,3 +9,5 @@ type Rgb = {
   g: number
   b: number
 }
+
+type ColorNumberInput = number | string


### PR DESCRIPTION
Created a shared `ColorNumberInput` type for better reusability in the scenarios where the color's number value is driven by user input and could be either a string or a number.