### PR TITLE
refactor: convert home page to TypeScript and refine some types

### DIFF
--- a/src/components/ColorField.tsx
+++ b/src/components/ColorField.tsx
@@ -52,8 +52,8 @@ type Props = {
   prefix?: string
   size?: number
   suffix?: string
-  updateColor: (val: ColorNumberInput) => void
-  value: ColorNumberInput
+  updateColor: (val: ColorFieldInput) => void
+  value: ColorFieldInput
 }
 
 const ColorField = (props: Props) => {

--- a/src/components/ColorSet.tsx
+++ b/src/components/ColorSet.tsx
@@ -157,18 +157,10 @@ const ColorSet = (props: Props) => {
 }
 
 type Props = {
-  colors: {
-    b: ColorNumberInput
-    g: ColorNumberInput
-    h: ColorNumberInput
-    hex: string
-    l: ColorNumberInput
-    r: ColorNumberInput
-    s: ColorNumberInput
-  }
+  colors: ColorSet
   header: string
   setIdentifier: string
-  updateColor: (key: string, val: ColorNumberInput) => void
+  updateColor: (key: string, val: ColorFieldInput) => void
 }
 
 export default ColorSet

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -79,7 +79,7 @@ const Header = ({ siteTitle }: Props) => (
           }}
           title={`${siteTitle} home`}
         >
-          <Logo height="40px" width="123px" aria-hidden="true" alt />
+          <Logo height="40px" width="123px" aria-hidden="true" />
           <LogoAlt>{siteTitle} home</LogoAlt>
         </Link>
       </SiteTitle>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -25,8 +25,13 @@ const StyledH2 = styled.h2`
   border-radius: 12px;
 `
 
+type State = {
+  background: ColorSet
+  foreground: ColorSet
+}
+
 class IndexPage extends Component {
-  state = {
+  state: State = {
     background: {
       h: 0,
       s: 0,
@@ -47,7 +52,7 @@ class IndexPage extends Component {
     },
   }
 
-  updateColors = (key, val, stateKey) => {
+  updateColors = (key: string, val: ColorFieldInput, stateKey: string) => {
     if (val === '') {
       this.setState(prevState => {
         const oldVals = prevState[stateKey]
@@ -89,7 +94,7 @@ class IndexPage extends Component {
         ...argSet,
       }
     } else {
-      const { hsl, rgb } = convertFromHex(val)
+      const { hsl, rgb } = convertFromHex(String(val))
       updatedValues = {
         ...hsl,
         ...rgb,
@@ -100,11 +105,11 @@ class IndexPage extends Component {
     this.setState({ [stateKey]: { ...updatedValues } })
   }
 
-  updateForegroundColors = (key, val) => {
+  updateForegroundColors = (key: string, val: ColorFieldInput) => {
     this.updateColors(key, val, 'foreground')
   }
 
-  updateBackgroundColors = (key, val) => {
+  updateBackgroundColors = (key: string, val: ColorFieldInput) => {
     this.updateColors(key, val, 'background')
   }
 

--- a/src/ts/index.d.ts
+++ b/src/ts/index.d.ts
@@ -10,4 +10,14 @@ type Rgb = {
   b: number
 }
 
-type ColorNumberInput = number | string
+type ColorFieldInput = number | string
+
+type ColorSet = {
+  b: number
+  g: number
+  h: number
+  hex: string
+  l: number
+  r: number
+  s: number
+}

--- a/src/ts/index.d.ts
+++ b/src/ts/index.d.ts
@@ -12,12 +12,4 @@ type Rgb = {
 
 type ColorFieldInput = number | string
 
-type ColorSet = {
-  b: number
-  g: number
-  h: number
-  hex: string
-  l: number
-  r: number
-  s: number
-}
+type ColorSet = Rgb & Hsl & { hex: string }


### PR DESCRIPTION
Related to #10 

## Changes

- Converted home page to TypeScript
- Cleaned up and made an additional shared type definition
- Remove a rogue `alt` prop in the header logo